### PR TITLE
Registration routine and uppercase Keyboard extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ https://www.nuget.org/packages/PINView.Maui/
 | FontAttributes | FontAttributes | None | Sets the FontAttributes of the Char label in each box. Applicable when IsPassword = False |
 | FontFamily | string | System Font | Sets the FontFamily of the Char label in each box. Applicable when IsPassword = False |
 | IsPassword | Boolean | False | Defines whether to show actual input character or hide / secure via Dot |
-| PINInputType | Enum | Numeric | Defines the Input Type from Enum [ Numeric, AlphaNumeric ] |
+| PINInputType | Enum | Numeric | Defines the Input Type from Enum [ Numeric, AlphaNumeric, AlphaNumericUppercase ] |
 | PINLength | Integer | 4 | Defines the Length (No. of Characters) of the PIN |
 | PINValue | String | Empty | Bind this to string Property in your ViewModel, to get value of the Entered PIN |
 

--- a/samples/PINView.Samples/MauiProgram.cs
+++ b/samples/PINView.Samples/MauiProgram.cs
@@ -7,9 +7,7 @@
             var builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
-#if ANDROID
-            .ConfigureMauiHandlers(handlers => handlers.AddHandler<Microsoft.Maui.Controls.Entry, Platforms.Android.Handlers.EntryHandler>())
-#endif
+                .UsePinView()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/samples/PINView.Samples/Views/SampleViews/PINInputTypeSampleView.xaml
+++ b/samples/PINView.Samples/Views/SampleViews/PINInputTypeSampleView.xaml
@@ -43,9 +43,24 @@
                         BoxBackgroundColor="{StaticResource LightColorC}"
                         IsPassword="False"
                         PINInputType="AlphaNumeric"
+                        PINValue="abcd"
+                        Style="{StaticResource PINViewStyle}"
+                        Color="{StaticResource ColorC}" />
+
+                    <Label
+                        Margin="0,20,0,0"
+                        HorizontalTextAlignment="Center"
+                        Text="PINInputType = AlphaNumericUppercase" />
+
+                    <pinView:PINView
+                        x:Name="pinView3"
+                        BoxBackgroundColor="{StaticResource LightColorC}"
+                        IsPassword="False"
+                        PINInputType="AlphaNumericUppercase"
                         PINValue="ABCD"
                         Style="{StaticResource PINViewStyle}"
                         Color="{StaticResource ColorC}" />
+
                 </StackLayout>
 
             </StackLayout>

--- a/src/PINView/BindableProperties/PINView.PINInputType.cs
+++ b/src/PINView/BindableProperties/PINView.PINInputType.cs
@@ -27,7 +27,7 @@ namespace PINView.Maui
         private static void PINInputTypePropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             var control = ((PINView)bindable);
-            control.SetInputType((InputKeyboardType)newValue);
+            control?.SetInputType((InputKeyboardType)newValue);
         }
 
         /// <summary>
@@ -36,15 +36,15 @@ namespace PINView.Maui
         /// <param name="inputKeyboardType"></param>
         public void SetInputType(InputKeyboardType inputKeyboardType)
         {
-            if (inputKeyboardType == InputKeyboardType.Numeric)
+            hiddenTextEntry.Keyboard = inputKeyboardType switch
             {
-                hiddenTextEntry.Keyboard = Keyboard.Numeric;
-            }
-            else if (inputKeyboardType == InputKeyboardType.AlphaNumeric)
-            {
-                // Keyboard.Create(0); : To remove the Hints on top of Keyboard, while typing
-                hiddenTextEntry.Keyboard = Keyboard.Create(0);
-            }
+                InputKeyboardType.Numeric => Keyboard.Numeric,
+                // Keyboard.Create(KeyboardFlags.None): To remove the Hints on top of Keyboard, while typing
+                InputKeyboardType.AlphaNumeric => Keyboard.Create(KeyboardFlags.None),
+                // Keyboard.Create(KeyboardFlags.None | KeyboardFlags.CapitalizeCharacter): To make the Keyboard uppercase by default
+                InputKeyboardType.AlphaNumericUppercase => Keyboard.Create(KeyboardFlags.None | KeyboardFlags.CapitalizeCharacter),
+                _ => hiddenTextEntry.Keyboard
+            };
         }
     }
 }

--- a/src/PINView/Helpers/InputKeyboardType.cs
+++ b/src/PINView/Helpers/InputKeyboardType.cs
@@ -3,6 +3,7 @@
     public enum InputKeyboardType
     {
         Numeric,
-        AlphaNumeric
+        AlphaNumeric,
+        AlphaNumericUppercase
     }
 }

--- a/src/PINView/HiddenPinEntry.cs
+++ b/src/PINView/HiddenPinEntry.cs
@@ -1,0 +1,3 @@
+﻿namespace PINView.Maui;
+
+public sealed class HiddenPinEntry : Entry { }

--- a/src/PINView/PINView.Maui.csproj
+++ b/src/PINView/PINView.Maui.csproj
@@ -39,14 +39,10 @@
 	</ItemGroup>
 	<ItemGroup>
 		<Folder Include="Converters\" />
-		<Folder Include="Platforms\Android\" />
-		<Folder Include="Platforms\MacCatalyst\" />
-		<Folder Include="Platforms\Windows\" />
-		<Folder Include="Platforms\Android\Handlers\" />
 	</ItemGroup>
 	<ItemGroup>
-		<None Include="..\..\arts\Package-Icon.png" Pack="true" PackagePath="\"/>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+		<None Include="..\..\arts\Package-Icon.png" Pack="true" PackagePath="\" />
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Update="BoxTemplate.cs">

--- a/src/PINView/PINView.xaml
+++ b/src/PINView/PINView.xaml
@@ -3,24 +3,25 @@
     x:Class="PINView.Maui.PINView"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:helpers="clr-namespace:PINView.Maui.Helpers">
+    xmlns:helpers="clr-namespace:PINView.Maui.Helpers"
+    xmlns:maui="clr-namespace:PINView.Maui">
     <ContentView.Content>
         <Grid HorizontalOptions="Start">
             <!--  This Textbox stays behind the scene to bring up the keyboard and take user input  -->
-            <Entry
+            <maui:HiddenPinEntry
                 x:Name="hiddenTextEntry"
                 HorizontalOptions="Center"
                 Keyboard="Numeric"
                 Opacity="0"
                 WidthRequest="50">
-                <Entry.FontSize>
+                <maui:HiddenPinEntry.FontSize>
                     <OnPlatform x:TypeArguments="x:Double">
                         <On Platform="Android" Value="18" />
                         <On Platform="iOS" Value="22" />
                         <On Platform="WinUI" Value="18" />
                     </OnPlatform>
-                </Entry.FontSize>
-            </Entry>
+                </maui:HiddenPinEntry.FontSize>
+            </maui:HiddenPinEntry>
             <HorizontalStackLayout
                 x:Name="PINBoxContainer"
                 InputTransparent="False"

--- a/src/PINView/PINView.xaml.cs
+++ b/src/PINView/PINView.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using PINView.Maui.Helpers;
-using System.ComponentModel;
 using System.Diagnostics;
 
 namespace PINView.Maui
@@ -10,7 +9,7 @@ namespace PINView.Maui
         #region Fields
 
         /// <summary>
-        /// A TapGuesture Recognizer to invoke when user tap on any PIN box. This will help bring up the soft keyboard
+        /// A TapGesture Recognizer to invoke when user tap on any PIN box. This will help bring up the soft keyboard
         /// </summary>
         private readonly TapGestureRecognizer boxTapGestureRecognizer;
 
@@ -51,10 +50,10 @@ namespace PINView.Maui
 
         private void HiddenTextEntry_Focused(object sender, FocusEventArgs e)
         {
-            var length = PINValue == null ? 0 : PINValue.Length;
+            var length = PINValue?.Length ?? 0;
 
             // When textbox is focused, Android brings cursor to the start of value, instead of end To fix this issue,
-            // added this programatic cursor movement to the last when focused
+            // added this programmatic cursor movement to the last when focused
             hiddenTextEntry.CursorPosition = length;
 
             var pinBoxArray = PINBoxContainer.Children.Select(x => x as BoxTemplate).ToArray();
@@ -119,7 +118,7 @@ namespace PINView.Maui
                     if (PINValue.Length >= PINLength)
                     {
                         boxTemplate.SetValueWithAnimation(pinCharsArray[Constants.DefaultPINLength + i - 1]);
-                    }                    
+                    }
                 }
             }
             else if (count > PINLength)
@@ -149,7 +148,7 @@ namespace PINView.Maui
 
             if (DeviceInfo.Platform == DevicePlatform.Android)
             {
-                // Added TapGuesture to all components of the Box so that if we tap anywhere
+                // Added TapGesture to all components of the Box so that if we tap anywhere
                 // It still gets the focus. In Android things are not working as expected otherwise.
                 boxTemplate.BoxBorder.GestureRecognizers.Add(boxTapGestureRecognizer);
                 boxTemplate.ValueContainer.GestureRecognizers.Add(boxTapGestureRecognizer);
@@ -157,7 +156,7 @@ namespace PINView.Maui
                 boxTemplate.CharLabel.GestureRecognizers.Add(boxTapGestureRecognizer);
             }
             else
-            { 
+            {
                 boxTemplate.GestureRecognizers.Add(boxTapGestureRecognizer);
             }
 
@@ -181,7 +180,7 @@ namespace PINView.Maui
         #region Events
 
         /// <summary>
-        /// Invokes when user type the PIN, Assignes value to PINValue property or Text changes in the hidden textbox
+        /// Invokes when user type the PIN, Assigns value to PINValue property or Text changes in the hidden textbox
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -196,21 +195,23 @@ namespace PINView.Maui
             // last entry / or animation.
             await Task.Delay(200);
 
-            if (e.NewTextValue.Length >= PINLength)
+            if (e.NewTextValue.Length < PINLength)
             {
-                // Dismiss the keyboard, once entry is completed up to the defined length and if AutoDismissKeyboard
-                // property is true
-                if (AutoDismissKeyboard == true)
-                {
-                    (sender as Entry).Unfocus();
-                    Debug.WriteLine($"{nameof(PINView)}: PIN Entry UnFocused");
-                }
-
-                Debug.WriteLine($"{nameof(PINView)}: PIN Entry Completed");
-
-                PINEntryCompleted?.Invoke(this, new PINCompletedEventArgs(PINValue));
-                PINEntryCompletedCommand?.Execute(PINValue);
+                return;
             }
+
+            // Dismiss the keyboard, once entry is completed up to the defined length and if AutoDismissKeyboard
+            // property is true
+            if (AutoDismissKeyboard == true)
+            {
+                (sender as HiddenPinEntry)?.Unfocus();
+                Debug.WriteLine($"{nameof(PINView)}: PIN Entry UnFocused");
+            }
+
+            Debug.WriteLine($"{nameof(PINView)}: PIN Entry Completed");
+
+            PINEntryCompleted?.Invoke(this, new PINCompletedEventArgs(PINValue));
+            PINEntryCompletedCommand?.Execute(PINValue);
         }
 
         #endregion Events

--- a/src/PINView/Platforms/Android/Handlers/HiddenPinEntryHandler.cs
+++ b/src/PINView/Platforms/Android/Handlers/HiddenPinEntryHandler.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using Android.Views.InputMethods;
+﻿using Android.Views.InputMethods;
 using AndroidX.AppCompat.Widget;
 using static Android.Views.View;
 
 namespace PINView.Maui.Platforms.Android.Handlers
 {
-    public partial class EntryHandler : Microsoft.Maui.Handlers.EntryHandler
+    public sealed class HiddenPinEntryHandler : Microsoft.Maui.Handlers.EntryHandler
     {
         protected override void ConnectHandler(AppCompatEditText platformView)
         {
@@ -23,13 +22,13 @@ namespace PINView.Maui.Platforms.Android.Handlers
         {
             if (args.HasFocus)
             {
-                InputMethodManager inputMethodManager = (InputMethodManager)global::Android.App.Application.Context.GetSystemService(global::Android.Content.Context.InputMethodService);
-                inputMethodManager.ShowSoftInput(PlatformView, ShowFlags.Forced);
+                var inputMethodManager = (InputMethodManager)global::Android.App.Application.Context.GetSystemService(global::Android.Content.Context.InputMethodService);
+                inputMethodManager?.ShowSoftInput(PlatformView, ShowFlags.Forced);
             }
             else
             {
-                InputMethodManager inputMethodManager = (InputMethodManager)global::Android.App.Application.Context.GetSystemService(global::Android.Content.Context.InputMethodService);
-                inputMethodManager.HideSoftInputFromWindow(PlatformView.WindowToken, HideSoftInputFlags.None);
+                var inputMethodManager = (InputMethodManager)global::Android.App.Application.Context.GetSystemService(global::Android.Content.Context.InputMethodService);
+                inputMethodManager?.HideSoftInputFromWindow(PlatformView.WindowToken, HideSoftInputFlags.None);
             }
         }
     }

--- a/src/PINView/Registration.cs
+++ b/src/PINView/Registration.cs
@@ -1,0 +1,16 @@
+﻿namespace PINView.Maui;
+
+public static class Registration
+{
+    public static MauiAppBuilder UsePinView(this MauiAppBuilder builder)
+    {
+#if ANDROID
+        builder.ConfigureMauiHandlers(h =>
+        {
+            h.AddHandler<HiddenPinEntry, Platforms.Android.Handlers.HiddenPinEntryHandler>();
+        });
+#endif
+
+        return builder;
+    }
+}


### PR DESCRIPTION
In short: Added registration routine with custom HiddenPinEntry class and extended PINInputType to allow all-uppercase keyboard.

**TL;DR**
Registration routines are common practice with MAUI controls. This simplifies the usage and reduces code repetition. Also, in this case, it prevents registering a shared custom handler for all Entry instances. Instead, a custom Entry class called `HiddenPinEntry` was introduced so that the custom handler only applies to instances of that specific type. Registration works simply by adding the following call in *MauiProgram.cs*:

```c#
var builder = MauiApp.CreateBuilder();

builder
    .UseMauiApp<App>()
    .UsePinView(); // this will register the required handler(s)

return builder.Build();
```

The PINInputType enum was extended with an `AlphaNumericUppercase` value so that an all-uppercase keyboard can be used. This is useful when alphanumeric PINs and access codes only allow uppercase characters.