### PR TITLE
Option to disable accessibility scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ https://www.nuget.org/packages/PINView.Maui/
 | FontSize | double | 20.0 | Sets the Font size of each char Label in PinBoxes |
 | FontAttributes | FontAttributes | None | Sets the FontAttributes of the Char label in each box. Applicable when IsPassword = False |
 | FontFamily | string | System Font | Sets the FontFamily of the Char label in each box. Applicable when IsPassword = False |
+| FontAccessibilityScalingEnabled | Boolean | True | Allows to disable font accessibility scaling, which is enabled by default in MAUI |
 | IsPassword | Boolean | False | Defines whether to show actual input character or hide / secure via Dot |
 | PINInputType | Enum | Numeric | Defines the Input Type from Enum [ Numeric, AlphaNumeric ] |
 | PINLength | Integer | 4 | Defines the Length (No. of Characters) of the PIN |

--- a/samples/PINView.Samples/Views/SampleViews/FontSizeSampleView.xaml
+++ b/samples/PINView.Samples/Views/SampleViews/FontSizeSampleView.xaml
@@ -45,7 +45,22 @@
                         FontSize="16"
                         Style="{StaticResource PINViewStyle}"
                         Color="{DynamicResource ColorA}" />
-                </StackLayout>
+
+                    <Label
+                      Margin="0,20,0,0"
+                      HorizontalTextAlignment="Center"
+                      Text="FontSize = 32, FontAccessibilityScalingEnabled = False" />
+                    <pinView:PINView
+                      x:Name="pinView3"
+                      BoxBackgroundColor="{DynamicResource LightColorA}"
+                      IsPassword="False"
+                      PINLength="5"
+                      PINValue="12345"
+                      FontSize="32"
+                      FontAccessibilityScalingEnabled="False"
+                      Style="{StaticResource PINViewStyle}"
+                      Color="{DynamicResource ColorA}" />
+        </StackLayout>
             </StackLayout>
         </Border>
     </ContentView.Content>

--- a/src/PINView/BindableProperties/PINView.FontAccessibilityScalingEnabled.cs
+++ b/src/PINView/BindableProperties/PINView.FontAccessibilityScalingEnabled.cs
@@ -1,0 +1,38 @@
+﻿namespace PINView.Maui;
+
+public partial class PINView
+{
+    /// <summary>
+    /// Enables or disables the font accessibility scaling for the PIN Box labels.
+    /// </summary>
+    public bool FontAccessibilityScalingEnabled
+    {
+        get => (bool)GetValue(FontAccessibilityScalingEnabledProperty);
+        set => SetValue(FontAccessibilityScalingEnabledProperty, value);
+    }
+
+    public static readonly BindableProperty FontAccessibilityScalingEnabledProperty =
+        BindableProperty.Create(
+            nameof(FontAccessibilityScalingEnabled),
+            typeof(bool),
+            typeof(PINView),
+            defaultValue: true,
+            defaultBindingMode: BindingMode.OneWay,
+            propertyChanged: FontAccessibilityScalingEnabledPropertyChanged);
+
+    private static void FontAccessibilityScalingEnabledPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is not PINView pinView)
+        {
+            return;
+        }
+
+        foreach (var box in pinView.PINBoxContainer.Children)
+        {
+            if (box is BoxTemplate boxTemplate)
+            {
+                boxTemplate.CharLabel.FontAutoScalingEnabled = (bool)newValue;
+            }
+        }
+    }
+}

--- a/src/PINView/PINView.xaml.cs
+++ b/src/PINView/PINView.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using PINView.Maui.Helpers;
-using System.ComponentModel;
 using System.Diagnostics;
 
 namespace PINView.Maui
@@ -119,7 +118,7 @@ namespace PINView.Maui
                     if (PINValue.Length >= PINLength)
                     {
                         boxTemplate.SetValueWithAnimation(pinCharsArray[Constants.DefaultPINLength + i - 1]);
-                    }                    
+                    }
                 }
             }
             else if (count > PINLength)
@@ -138,26 +137,34 @@ namespace PINView.Maui
         /// <returns></returns>
         private BoxTemplate CreateBox(char? charValue = null)
         {
-            BoxTemplate boxTemplate = new BoxTemplate();
-            boxTemplate.HeightRequest = BoxSize;
-            boxTemplate.WidthRequest = BoxSize;
-            boxTemplate.BoxBorder.BackgroundColor = BoxBackgroundColor;
-            boxTemplate.CharLabel.FontSize = BoxSize / 2;
-            boxTemplate.CharLabel.FontFamily = FontFamily;
-            boxTemplate.CharLabel.FontAttributes = FontAttributes;
-            boxTemplate.CharLabel.FontSize = FontSize;
+            var boxTemplate = new BoxTemplate
+            {
+                HeightRequest = BoxSize,
+                WidthRequest = BoxSize,
+                BoxBorder =
+                {
+                    BackgroundColor = BoxBackgroundColor
+                },
+                CharLabel =
+                {
+                    FontFamily = FontFamily,
+                    FontAttributes = FontAttributes,
+                    FontSize = FontSize,
+                    FontAutoScalingEnabled = FontAccessibilityScalingEnabled
+                }
+            };
 
             if (DeviceInfo.Platform == DevicePlatform.Android)
             {
-                // Added TapGuesture to all components of the Box so that if we tap anywhere
-                // It still gets the focus. In Android things are not working as expected otherwise.
+                // Added TapGesture to all components of the Box so that if we tap anywhere,
+                // it still gets the focus. On Android things are not working as expected otherwise.
                 boxTemplate.BoxBorder.GestureRecognizers.Add(boxTapGestureRecognizer);
                 boxTemplate.ValueContainer.GestureRecognizers.Add(boxTapGestureRecognizer);
                 boxTemplate.Dot.GestureRecognizers.Add(boxTapGestureRecognizer);
                 boxTemplate.CharLabel.GestureRecognizers.Add(boxTapGestureRecognizer);
             }
             else
-            { 
+            {
                 boxTemplate.GestureRecognizers.Add(boxTapGestureRecognizer);
             }
 


### PR DESCRIPTION
The PINView currently doesn't handle MAUI's `FontAutoScalingEnabled` property, which by default is set to `true`: https://learn.microsoft.com/dotnet/maui/user-interface/fonts. 

This is problematic, because it means that if a user has enabled accessibility scaling on their iPhone or Android device, the text in the PINView's boxes may become too large and exceed the bounds of the individual character labels.

Conserving the existing default behavior, this PR adds a `FontAccessbilityScalingEnabled` property, which simply passes the value down to each character label of the control, so that if it's set to `false` no font scaling will be done even if the user has accessibility scaling enabled. That way, we can ensure that the PINView is still displayed correctly.

Developers can choose to use this at will, it's not a breaking change.